### PR TITLE
fix maximum Coal availability

### DIFF
--- a/src/Data/Data.ts
+++ b/src/Data/Data.ts
@@ -19,7 +19,7 @@ export class Data
 		Desc_OreIron_C: 70380,
 		Desc_OreCopper_C: 28860,
 		Desc_Stone_C: 52860,
-		Desc_Coal_C: 30900,
+		Desc_Coal_C: 30120,
 		Desc_OreGold_C: 11040,
 		Desc_LiquidOil_C: 11700,
 		Desc_RawQuartz_C: 10500,


### PR DESCRIPTION
Patch 0.8.2.0 has removed a duplicate pure Coal node, bringing the total tally from 6+29+15 Coal nodes to 6+29+14 (impure + normal + pure).

Ref: <https://satisfactory.wiki.gg/wiki/Patch_0.8.2.0> (under "Bug Fixes": "Removed a duplicate coal node")

Closes #124.