### PR TITLE
Added (secret) urlparameter to switch the MachineGroupMode

### DIFF
--- a/src/Tools/Production/Result/MachineGroup.ts
+++ b/src/Tools/Production/Result/MachineGroup.ts
@@ -12,6 +12,14 @@ export class MachineGroup
 
 	public constructor(public recipeData: RecipeData, public mode: MachineGroupMode = 'underclockLast')
 	{
+		// could be done better in some new "options tab". But at least it works..?
+		const url = new URL(window.location.href);
+		const params = new URLSearchParams(url.search);
+		const urlParamMode = params.get('MachineGroupMode') as MachineGroupMode;
+		if (urlParamMode) {
+			this.mode = urlParamMode;
+		}
+		
 		this.recalculate();
 	}
 


### PR DESCRIPTION
As suggested in Discord, this adds an url parameter "MachineGroupMode" that sets the mode for the underclock calculations.

For example "https://www.satisfactorytools.com/1.0/production?MachineGroupMode=underclockEqually" would use underclockEqually instead of the default underclockLast.