### PR TITLE
Fluid miner update to data1.0.json

### DIFF
--- a/data/data1.0.json
+++ b/data/data1.0.json
@@ -41360,6 +41360,16 @@
             "allowSolids": true,
             "itemsPerCycle": 1,
             "extractCycleTime": 1.0
+        },
+        "Desc_WaterPump_C": {
+            "className": "Desc_WaterPump_C",
+            "allowedResources": [
+                "Desc_Water_C"
+            ],
+            "allowLiquids": true,
+            "allowSolids": false,
+            "itemsPerCycle": 2,
+            "extractCycleTime": 1.0
         }
     },
     "buildings": {

--- a/data/data1.0.json
+++ b/data/data1.0.json
@@ -41289,7 +41289,7 @@
             ],
             "allowLiquids": true,
             "allowSolids": false,
-            "itemsPerCycle": 2000,
+            "itemsPerCycle": 2,
             "extractCycleTime": 1.0
         },
         "Desc_MinerMk2_C": {


### PR DESCRIPTION
* Changed `Desc_OilPump_C` `itemsPerCycle` from litres to m3 since that is what's being used by the recipes. An OilPump will by default output 120 m3/minute, which is 2 per second, which is `miner.itemsPerCycle / miner.extractCycleTime`
* Added `Desc_WaterPump_C` to miners

I'm not sure if data1.0.json is actually used in this repo - I couldnt find any references to e.g. `Desc_OilPump_C` - but I found it incredibly useful (thanks!) so I guess at the very least others might, too.