### PR TITLE
Redirect the root page to 1.0 by default rather than 0.8

### DIFF
--- a/src/Module/AppModule.ts
+++ b/src/Module/AppModule.ts
@@ -363,7 +363,7 @@ export class AppModule
 				const valid = ['0.8', '1.0'];
 				if (!valid.includes(version)) {
 					transition.abort();
-					$state.go(transition.to().name + '', {...transition.params(), version: '0.8'}, {location: 'replace', reload: true, inherit: true});
+					$state.go(transition.to().name + '', {...transition.params(), version: '1.0'}, {location: 'replace', reload: true, inherit: true});
 				}
 			})
 


### PR DESCRIPTION
When loading the root page (for example, if you're visiting from a search engine), the app redirects to the 0.8 version, which then shows a modal recommending to switch to 1.0.
Most folks are probably running on 1.0 rather than 0.8. So requiring an additional click like this seems pointless.

This change will redirect from root to 1.0 instead.