### PR TITLE
Partial completion and sub-graph selection

### DIFF
--- a/.docker/nginx/conf.d/domain.conf
+++ b/.docker/nginx/conf.d/domain.conf
@@ -1,0 +1,27 @@
+server {
+    listen 80 default_server;
+
+    root /var/www/www;
+    index index.php index.html index.htm;
+
+    client_max_body_size 100M;
+
+    location / {
+         try_files $uri $uri/ /index.php$is_args$args;
+    }
+
+    location ~ \.php$ {
+        try_files $uri /index.php =404;
+        fastcgi_pass php:9000;
+        fastcgi_index index.php;
+
+        fastcgi_buffer_size 128k;
+        fastcgi_buffers 4 256k;
+        fastcgi_busy_buffers_size 256k;
+
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        #fixes timeouts
+        fastcgi_read_timeout 600;
+        include fastcgi_params;
+    }
+}

--- a/.docker/node/docker-entrypoint.sh
+++ b/.docker/node/docker-entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -e
+
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+	set -- node "$@"
+fi
+
+if [ "$1" = 'node' ] || [ "$1" = 'yarn' ]; then
+	yarn install
+
+	>&2 echo "Waiting for PHP to be ready..."
+	until nc -z "$PHP_HOST" "$PHP_PORT"; do
+		sleep 1
+	done
+fi
+
+exec "$@"

--- a/.docker/php/docker-entrypoint.sh
+++ b/.docker/php/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+	set -- php-fpm "$@"
+fi
+
+exec docker-php-entrypoint "$@"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,57 @@
+ARG PHP_VERSION=8.0
+ARG NODE_VERSION=16
+ARG NGINX_VERSION=1.27.3
+
+######### PHP CONFIG
+FROM php:${PHP_VERSION}-fpm-alpine as php
+
+WORKDIR /srv/app
+COPY www www/
+
+EXPOSE 9000
+
+COPY ./.docker/php/docker-entrypoint.sh /usr/local/bin/docker-entrypoint
+RUN chmod +x /usr/local/bin/docker-entrypoint
+
+ENTRYPOINT ["docker-entrypoint"]
+CMD ["php-fpm"]
+
+######### NODE CONFIG
+FROM node:${NODE_VERSION}-alpine as node
+
+WORKDIR /srv/app
+
+RUN apk update; \
+    apk add yarn;
+RUN apk add --no-cache --virtual .build-deps alpine-sdk python3
+
+# prevent the reinstallation of vendors at every changes in the source code
+COPY package.json yarn.lock ./
+COPY tsconfig.json tslint.json webpack.config.js ./
+COPY src src/
+COPY styles styles/
+COPY templates templates/
+COPY bin bin/
+COPY data data/
+
+RUN set -eux; \
+	yarn install; \
+	yarn cache clean; \
+    yarn build
+
+RUN apk del .build-deps
+
+COPY ./.docker/node/docker-entrypoint.sh /usr/local/bin/docker-entrypoint
+RUN chmod +x /usr/local/bin/docker-entrypoint
+
+ENTRYPOINT ["docker-entrypoint"]
+CMD ["yarn", "start"]
+
+######### NGINX CONFIG
+FROM nginx:${NGINX_VERSION}-alpine as nginx
+COPY .docker/nginx/conf.d/domain.conf /etc/nginx/conf.d/default.conf
+
+WORKDIR /srv/app
+
+COPY --from=node /srv/app/www/assets www/assets
+COPY --from=php /srv/app/www/index.php www/index.php

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # SatisfactoryTools
 Satisfactory Tools for planning and building the perfect base.
 
+# Standard application development
 ## Requirements
 - node.js version 16 (lower may work, 17+ doesn't work)
 - yarn
@@ -12,14 +13,25 @@ Satisfactory Tools for planning and building the perfect base.
 - `yarn build`
 - Set up a virtual host pointing to `/www` directory (using e.g. Apache or ngnix)
 
+## Development
+Run `yarn start` to start the automated build process. It will watch over the code and rebuild it on change.
+
+# Dockerized application development
+## Requirements
+- docker
+- docker-compose
+
+## Installation / Building
+- docker build .
+
+## Development
+- docker compose up -d
+
 ## Contributing
 Any pull requests are welcome, though some rules must be followed:
 - try to follow current coding style (there's `tslint` and `.editorconfig`, those should help you with that)
 - one PR per feature
 - all PRs must target `dev` branch
-
-## Development
-Run `yarn start` to start the automated build process. It will watch over the code and rebuild it on change.
 
 ## Updating data
 Get the latest Docs.json from your game installation and place it into `data` folder.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,38 @@
+version: "3.2"
+services:
+    nginx:
+        build:
+            context: .
+            target: nginx
+        depends_on:
+            - php
+            - node
+        ports:
+            - "80:80"
+        links:
+            - php
+        volumes:
+            - ./.docker/nginx/conf.d/domain.conf:/etc/nginx/conf.d/default.conf:ro
+            - ./www:/var/www/www:ro
+    php:
+        build:
+            context: .
+            target: php
+        depends_on:
+            - node
+        volumes:
+            - ./www:/var/www/www
+            - ./node_modules:/var/www/node_modules
+    node:
+        build:
+            context: .
+            target: node
+        environment:
+            PHP_HOST: php
+            PHP_PORT: 9000
+        volumes:
+            - ./src:/var/www/src
+            - ./styles:/var/www/styles
+            - ./templates:/var/www/templates
+            - ./bin:/var/www/bin
+            - ./data:/var/www/data

--- a/package.json
+++ b/package.json
@@ -5,9 +5,10 @@
 	"author": "greeny",
 	"private": true,
 	"scripts": {
-		"build": "export SET NODE_OPTIONS=--openssl-legacy-provider && webpack --mode production",
+		"build": "webpack --mode production",
 		"buildCI": "webpack --mode production",
-		"start": "export SET NODE_OPTIONS=--openssl-legacy-provider && webpack --mode development --progress --color --watch",
+		"start": "webpack --mode development --progress --color --watch",
+		"serve": "webpack serve --open",
 		"parseDocs": "ts-node -r tsconfig-paths/register bin/parseDocs.ts",
 		"parsePak": "ts-node -r tsconfig-paths/register bin/parsePak.ts",
 		"generateImages": "ts-node -r tsconfig-paths/register bin/generateImages.ts"

--- a/src/Module/Components/VisualizationComponent.ts
+++ b/src/Module/Components/VisualizationComponent.ts
@@ -8,6 +8,7 @@ export class VisualizationComponent implements IComponentOptions
 	public controller = VisualizationComponentController;
 	public bindings = {
 		result: '=',
+		settings: '=',
 	};
 
 }

--- a/src/Module/Controllers/ProductionController.ts
+++ b/src/Module/Controllers/ProductionController.ts
@@ -33,6 +33,7 @@ export class ProductionController
 	public readonly alternateRecipes: IRecipeSchema[] = data.getAlternateRecipes();
 	public readonly basicRecipes: IRecipeSchema[] = data.getBaseItemRecipes();
 	public readonly machines: IBuildingSchema[] = data.getManufacturers();
+	public readonly recipes: IRecipeSchema[] = this.basicRecipes.concat(this.alternateRecipes);
 
 	public result: string;
 

--- a/src/Tools/Production/IProductionData.ts
+++ b/src/Tools/Production/IProductionData.ts
@@ -31,6 +31,7 @@ export interface IProductionDataRequest
 
 	production: IProductionDataRequestItem[];
 	input: IProductionDataRequestInput[];
+	completed?: IProductionDataRequestCompleted[];
 
 }
 
@@ -56,6 +57,14 @@ export interface IProductionDataRequestInput
 
 	item: string|null; // classname of the item
 	amount: number; // amount of items/min
+
+}
+
+export interface IProductionDataRequestCompleted
+{
+
+	recipe: string|null; // classname of the recipe
+	amount: number; // amount of factories executing the recipe
 
 }
 

--- a/src/Tools/Production/Result/CalcCompleted.ts
+++ b/src/Tools/Production/Result/CalcCompleted.ts
@@ -1,0 +1,142 @@
+import { Numbers } from '@src/Utils/Numbers';
+import { Graph } from './Graph';
+import { ByproductNode } from './Nodes/ByproductNode';
+import { ProductNode } from './Nodes/ProductNode';
+import { RecipeNode } from './Nodes/RecipeNode';
+import { SinkNode } from './Nodes/SinkNode';
+
+export class CalcCompleted {
+	private indent: number = 0;
+
+	public constructor(protected readonly graph: Graph) { }
+
+	public update() {
+		this.resetConsumed();
+		this.updateInternal();
+		this.updateVisibility();
+	}
+
+	protected updateInternal() {
+		if (this.graph.settings.applyCompleted) {
+			for (const node of this.graph.nodes) {
+				if (node instanceof RecipeNode) {
+					if (this.graph.completedMap[node.recipeData.recipe.className]) {
+						this.updateNodeCompletion(node);
+					}
+				}
+			}
+		}
+	}
+
+	protected resetConsumed() {
+		for (const node of this.graph.nodes) {
+			if (node instanceof RecipeNode) {
+				(node as RecipeNode).completed = 0;
+				(node as RecipeNode).limit = undefined;
+			}
+
+			for (const edge of node.connectedEdges) {
+				edge.itemAmount.consumed = 0;
+				edge.itemAmount.limit = undefined;
+			}
+		}
+	}
+
+	protected updateVisibility() {
+		for (const node of this.graph.nodes) {
+			const output = Numbers.round(node
+				.getEdgesOut()
+				.map((x) => x.itemAmount.getAvailable())
+				.reduce((acc, sum) => acc + sum, 0));
+
+			node.visible = node.isAvailable()
+				&& (this.graph.settings.showCompleted
+					|| output > 0
+					|| node instanceof ProductNode
+					|| node instanceof SinkNode
+					|| node instanceof ByproductNode
+					|| node.highlighted === 'product'
+					|| node.highlighted === 'dependent');
+		}
+	}
+
+	private updateNodeCompletion(node: RecipeNode): void {
+		const indent = '   |'.repeat(this.indent)
+		const outputsUsed = node.getOutputs().map((output) => {
+			let consumed = 0;
+			let total = 0;
+
+			for (const edge of node.getEdgesOut(output.resource.className)) {
+				if (edge.to.isAvailable() && !edge.isLoop()) {
+					consumed += edge.itemAmount.consumed;
+					total += edge.itemAmount.getAmount();
+				}
+			}
+
+			return total === 0
+				? 1.0
+				: consumed / total;
+		});
+
+		const outputUsed = Math.min(...outputsUsed);
+		const outputCompleted = outputUsed * node.getAmount();
+
+		const userCompleted = this.graph.completedMap[node.recipeData.recipe.className] || 0.0;
+
+		const completedTotal = Math.min(outputCompleted + userCompleted, node.getAmount());
+
+		this.setNodeCompleted(node, completedTotal);
+	}
+
+	private setNodeCompleted(node: RecipeNode, completed: number) {
+		const diff = completed - node.completed;
+		if (Numbers.floor(diff) <= 0) {
+			return;
+		}
+
+		node.completed = completed;
+		const inputs = node.getInputs();
+		const multiplier = node.getMultiplier(diff);
+
+		for (const input of inputs) {
+			const ingredient = node.recipeData.recipe.ingredients.find((x) => x.item === input.resource.className);
+			if (!ingredient) {
+				continue;
+			}
+
+			const edges = node.getEdgesIn(input.resource.className);
+			const inputAmount = ingredient.amount * multiplier;
+			const totalAvailable = edges
+				.map((edge) => edge.from.isAvailable()
+					? edge.itemAmount.getAvailable()
+					: 0.0)
+				.reduce((acc, sum) => acc + sum, 0);
+
+			if (totalAvailable <= 0) {
+				continue;
+			}
+
+			for (const edge of edges) {
+				if (!edge.from.isAvailable()) {
+					continue;
+				}
+
+				const edgeAvailable = edge.itemAmount.getAvailable();
+				const ratio = edgeAvailable / totalAvailable;
+				const relativeEdgeAmount = ratio * inputAmount;
+				const consumed = edge.itemAmount.increaseConsumed(relativeEdgeAmount);
+			}
+		}
+
+		for (const edge of node.getEdgesIn()) {
+			if (	edge.from.isAvailable()
+				&&  edge.to !== edge.from
+				&& 	edge.from instanceof RecipeNode)
+			{
+				this.indent += 1;
+				this.updateNodeCompletion(edge.from);
+				this.indent -= 1;
+			}
+		}
+	}
+}

--- a/src/Tools/Production/Result/CalcHighlight.ts
+++ b/src/Tools/Production/Result/CalcHighlight.ts
@@ -1,0 +1,228 @@
+import { Numbers } from '@src/Utils/Numbers';
+import { CalcCompleted } from './CalcCompleted';
+import { GraphNode, HighlightState } from './Nodes/GraphNode';
+import { RecipeNode } from './Nodes/RecipeNode';
+
+export class CalcHighlight extends CalcCompleted {
+	private cache: NodeCache = { };
+
+	public set(node: GraphNode) {
+		if (this.graph.highlightedNode === node) {
+			this.graph.highlightedNode = undefined;
+		} else {
+			this.graph.highlightedNode = node;
+		}
+
+		this.update();
+	}
+
+	public update() {
+		let limit = 0;
+		if (this.graph.highlightedNode instanceof RecipeNode) {
+			limit = this.graph.highlightedNode.limit || this.graph.highlightedNode.recipeData.amount;
+		}
+
+		super.resetConsumed();
+
+		if (!this.graph.highlightedNode) {
+			for (const n of this.graph.nodes) {
+				n.highlighted = undefined;
+			}
+		} else {
+			for (const n of this.graph.nodes) {
+				this.cache[n.id] = this.cache[n.id] || {};
+				const cache = this.cache[n.id];
+				cache.highlighted = n.highlighted;
+
+				n.highlighted = 'unrelated';
+			}
+
+			this.graph.highlightedNode.highlighted = 'highlighted';
+
+			this.setHighlighted(this.graph.highlightedNode, true, true);
+
+			if (this.graph.settings.showHighlightLimits) {
+				if (this.graph.highlightedNode instanceof RecipeNode) {
+					this.setNodeLimit(this.graph.highlightedNode, limit);
+				}
+
+				if (this.graph.settings.showHighlightDependents) {
+					for (const node of this.graph.nodes) {
+						if (node instanceof RecipeNode) {
+							const recipeNode = node as RecipeNode;
+							this.setNodeLimit(node, node.recipeData.amount);
+						}
+					}
+				}
+			}
+		}
+
+		super.updateInternal();
+		super.updateVisibility();
+	}
+
+	private setHighlighted(node: GraphNode, showDependencies: boolean, showDependents: boolean): void {
+		this.cache[node.id] = this.cache[node.id] || { }
+
+		const cache = this.cache[node.id];
+
+		if (	(!showDependents || (showDependents === cache.showDependents))
+			&& 	(!showDependencies || (showDependencies === cache.showDependencies))) {
+			return;
+		}
+
+		if (showDependents) {
+			cache.showDependents = true;
+
+			for (const edge of node.getEdgesOut()) {
+				if (edge.to.highlighted === 'unrelated') {
+					const oldState = this.cache[edge.to.id]?.highlighted;
+
+					if (node.highlighted === 'highlighted'
+						&& (oldState === undefined
+							|| oldState === 'dependency'
+							|| oldState === 'highlighted'
+							|| oldState === 'product'))
+					{
+						edge.to.highlighted = 'product';
+					} else if (this.graph.settings.showHighlightDependents) {
+						edge.to.highlighted = 'dependent';
+					}
+				}
+
+				this.setHighlighted(edge.to, false, false);
+			}
+		}
+
+		if (showDependencies) {
+			cache.showDependencies = true;
+
+			for (const edge of node.getEdgesIn()) {
+				if (edge.from.highlighted === 'unrelated' || edge.from.highlighted === 'dependent') {
+					edge.from.highlighted = 'dependency';
+				}
+
+				this.setHighlighted(edge.from, true, edge.from instanceof RecipeNode);
+			}
+		}
+	}
+
+	private setNodeLimit(node: RecipeNode, limit: number): void {
+		const diff = limit - (node.limit || 0);
+		if (Numbers.floor(diff) <= 0) {
+			return;
+		}
+
+		node.limit = limit;
+
+		const multiplier = node.getMultiplier(diff);
+
+		if (node.highlighted === 'highlighted' || node.highlighted === 'dependent' || node.highlighted === 'dependency') {
+			for (const input of node.getInputs()) {
+				const ingredient = node.recipeData.recipe.ingredients.find((x) => x.item === input.resource.className);
+				if (!ingredient) {
+					continue;
+				}
+
+				let inputAmount = ingredient.amount * multiplier;
+
+				for (const edge of node.getEdgesIn(input.resource.className)) {
+					if (!edge.from.isAvailable()) {
+						continue;
+					}
+
+					const consumed = edge.itemAmount.increaseLimit(inputAmount);
+					inputAmount -= consumed;
+				}
+			}
+
+			for (const edge of node.getEdgesIn()) {
+				if (edge.from instanceof RecipeNode) {
+					this.updateNodeLimit(edge.from);
+				}
+			}
+		}
+
+		if (node.highlighted === 'highlighted') {
+			for (const output of node.getOutputs()) {
+				const product = node.recipeData.recipe.products.find((x) => x.item === output.resource.className);
+				if (!product) {
+					continue;
+				}
+
+				let outputAmount = product.amount * multiplier;
+
+				for (const edge of node.getEdgesOut(output.resource.className)) {
+					if (!edge.to.isAvailable()) {
+						continue;
+					}
+
+					outputAmount -= edge.itemAmount.increaseLimit(outputAmount);
+				}
+			}
+
+			for (const edge of node.getEdgesOut()) {
+				if (edge.to instanceof RecipeNode) {
+					this.updateNodeLimit(edge.to);
+				}
+			}
+		}
+	}
+
+	private updateNodeLimit(node: RecipeNode): void {
+		if (this.cache[node.id]?.visited) {
+			return;
+		}
+
+		this.cache[node.id] = this.cache[node.id] || {};
+		const cache = this.cache[node.id];
+		cache.visited = true;
+
+		if (node.highlighted === 'product') {
+			const inputsUsed = node.getInputs().map((input) => {
+				const limit = node
+					.getEdgesIn(input.resource.className)
+					.map((edge) => edge.from.isAvailable()
+						? (edge.itemAmount.limit || 0)
+						: edge.itemAmount.amount)
+					.reduce((acc, sum) => acc + sum, 0);
+				const total = input.maxAmount;
+
+				return limit / total;
+			});
+			const inputUsed = Math.min(...inputsUsed);
+			const inputLimit = inputUsed * node.recipeData.amount;
+
+			this.setNodeLimit(node, inputLimit);
+		} else if (node.highlighted === 'dependency') {
+			const outputsUsed = node.getOutputs().map((output) => {
+				const limit = node
+					.getEdgesOut(output.resource.className)
+					.map((edge) => edge.to.isAvailable()
+						? (edge.itemAmount.limit || 0)
+						: 0)
+					.reduce((acc, sum) => acc + sum, 0);
+				const total = output.maxAmount;
+
+				return limit / total;
+			});
+			const outputUsed = Math.max(...outputsUsed);
+			const outputLimit = outputUsed * node.recipeData.amount;
+
+			this.setNodeLimit(node, outputLimit);
+		}
+
+		cache.visited = false;
+	}
+}
+
+interface NodeState {
+	visited?: boolean,
+	highlighted?: HighlightState,
+	showDependents?: boolean;
+	showDependencies?: boolean;
+}
+
+interface NodeCache {
+	[key:number]: NodeState;
+}

--- a/src/Tools/Production/Result/Edges/GraphEdge.ts
+++ b/src/Tools/Production/Result/Edges/GraphEdge.ts
@@ -1,5 +1,7 @@
+import model from '@src/Data/Model';
 import {GraphNode} from '@src/Tools/Production/Result/Nodes/GraphNode';
 import {ItemAmount} from '@src/Tools/Production/Result/ItemAmount';
+import { Strings } from '@src/Utils/Strings';
 
 export class GraphEdge
 {
@@ -8,8 +10,26 @@ export class GraphEdge
 
 	public constructor(public readonly from: GraphNode, public readonly to: GraphNode, public readonly itemAmount: ItemAmount)
 	{
-		from.connectedEdges.push(this);
-		to.connectedEdges.push(this);
+		if (this.to === this.from) {
+			this.to.connectedEdges.push(this);
+		} else {
+			this.from.connectedEdges.push(this);
+			this.to.connectedEdges.push(this);
+		}
+	}
+
+	public getText(): string {
+		const missing = this.itemAmount.getAvailable();
+		const amount = Strings.formatNumber(this.itemAmount.getAmount());
+		const amountText = this.itemAmount.consumed
+			? Strings.formatNumber(missing) + ' of ' + amount
+			: amount;
+
+		return model.getItem(this.itemAmount.item).prototype.name + '\n' + amountText + ' / min';
+	}
+
+	public isLoop(): boolean {
+		return this.to.hasOutputTo(this.from);
 	}
 
 }

--- a/src/Tools/Production/Result/Graph.ts
+++ b/src/Tools/Production/Result/Graph.ts
@@ -1,20 +1,39 @@
 import {GraphNode} from '@src/Tools/Production/Result/Nodes/GraphNode';
 import {GraphEdge} from '@src/Tools/Production/Result/Edges/GraphEdge';
 import {ItemAmount} from '@src/Tools/Production/Result/ItemAmount';
+import {IProductionDataRequestCompleted} from '@src/Tools/Production/IProductionData';
+import {CalcHighlight} from '@src/Tools/Production/Result/CalcHighlight';
+import {Numbers} from '@src/Utils/Numbers';
+
+export interface GraphSettings {
+	applyCompleted: boolean,
+	showCompleted: boolean,
+	showHighlightDependents: boolean,
+	showHighlightLimits: boolean,
+}
 
 export class Graph
 {
 
-	public readonly DELTA = 1e-8;
-
 	public nodes: GraphNode[] = [];
 	public edges: GraphEdge[] = [];
+	public completedMap: CompletedMap = { };
+	public highlightedNode?: GraphNode;
 
 	private lastId = 1;
+	private outputToNodeMap?: ItemToNodeMap;
+
+	public constructor(public settings: GraphSettings) { }
+
+	public setSettings(settings: GraphSettings) {
+		this.settings = settings;
+		this.recalculate();
+	}
 
 	public addNode(node: GraphNode): void
 	{
 		this.nodes.push(node);
+		this.outputToNodeMap = undefined;
 		node.id = this.lastId++;
 	}
 
@@ -24,36 +43,99 @@ export class Graph
 		edge.id = this.lastId++;
 	}
 
-	public generateEdges(): void
+	public highlight(node: GraphNode) {
+		new CalcHighlight(this).set(node);
+	}
+
+	public generateEdges(completed: IProductionDataRequestCompleted[]): void
 	{
-		for (const nodeOut of this.nodes) {
-			outputLoop:
-			for (const output of nodeOut.getOutputs()) {
+		this.edges = [];
+		this.completedMap = { };
 
-				for (const nodeIn of this.nodes) {
-					for (const input of nodeIn.getInputs()) {
-						if (input.resource === output.resource && input.amount < input.maxAmount) {
-							const diff = Math.min(input.maxAmount - input.amount, output.amount);
+		const outputToNodeMap = this.getOutputToNodeMap();
 
-							output.amount -= diff;
-							input.amount += diff;
-							if (Math.abs(input.maxAmount - input.amount) < this.DELTA) {
-								input.amount = input.maxAmount;
-							}
-							if (Math.abs(output.amount) < this.DELTA) {
-								output.amount = 0;
-							}
+		for (const item of completed) {
+			if (item.recipe) {
+				this.completedMap[item.recipe] = (this.completedMap[item.recipe] || 0) + item.amount;
+			}
+		}
 
-							this.addEdge(new GraphEdge(nodeOut, nodeIn, new ItemAmount(output.resource.className, diff)));
+		for (const checkSharedResources of [true, false]) {
+			for (const nodeIn of this.nodes) {
+				for (const input of nodeIn.getInputs()) {
+					const nodesOut = outputToNodeMap[input.resource.className];
+					for (const nodeOut of nodesOut) {
+						if (checkSharedResources && !hasSharedResources(nodeIn, nodeOut)) {
+							continue;
+						}
 
-							if (output.amount === 0) {
-								continue outputLoop;
+						for (const output of nodeOut.getOutputs()) {
+							if (input.resource === output.resource && input.amount < input.maxAmount) {
+								const diff = Numbers.round(Math.min(input.maxAmount - input.amount, output.amount));
+
+								if (diff <= 0) {
+									continue;
+								}
+
+								output.decrease(diff);
+								input.increase(diff);
+
+								this.addEdge(new GraphEdge(nodeOut, nodeIn, new ItemAmount(output.resource.className, diff)));
 							}
 						}
 					}
 				}
 			}
 		}
+
+		this.recalculate();
+	}
+
+	private recalculate() {
+		new CalcHighlight(this).update();
+	}
+
+	private getOutputToNodeMap(): ItemToNodeMap {
+		if (!this.outputToNodeMap) {
+			this.outputToNodeMap = { };
+
+			for (const node of this.nodes) {
+				for (const output of node.getOutputs()) {
+					const className = output.resource.className;
+					const  nodeList = this.outputToNodeMap[className] || [];
+					nodeList.push(node);
+					this.outputToNodeMap[className] = nodeList;
+				}
+			}
+		}
+
+		return this.outputToNodeMap;
 	}
 
 }
+
+function hasSharedResources(nodeIn: GraphNode, nodeOut: GraphNode): boolean {
+	let sharedInputs = 0;
+	let sharedOutputs = 0;
+
+	for (const input of nodeIn.getInputs()) {
+		for (const output of nodeOut.getOutputs()) {
+			if (input.resource === output.resource) {
+				++sharedInputs;
+			}
+		}
+	}
+
+	for (const output of nodeIn.getOutputs()) {
+		for (const input of nodeOut.getInputs()) {
+			if (input.resource === output.resource) {
+				++sharedOutputs;
+			}
+		}
+	}
+
+	return (sharedInputs > 0) && (sharedOutputs > 0);
+}
+
+interface ItemToNodeMap { [key:string]: GraphNode[] }
+interface CompletedMap { [key:string]: number }

--- a/src/Tools/Production/Result/ItemAmount.ts
+++ b/src/Tools/Production/Result/ItemAmount.ts
@@ -1,9 +1,49 @@
+import { Numbers } from '@src/Utils/Numbers';
+
 export class ItemAmount
 {
 
+	public consumed: number = 0.0;
+	public limit?: number;
+
 	public constructor(public readonly item: string, public amount: number)
 	{
-		//
+	}
+
+	public increaseConsumed(diff: number): number {
+		const available = this.getAvailable();
+		const maxDiff = Math.min(available, diff);
+
+		this.consumed = Numbers.round(this.consumed + maxDiff);
+
+		return maxDiff;
+	}
+
+	public increaseLimit(diff: number): number {
+		const buffer = this.getBuffer();
+		const maxDiff = Math.min(buffer, diff);
+
+		this.limit = Numbers.round((this.limit || 0) + maxDiff);
+
+		return maxDiff;
+	}
+
+	public getConsumed(): number {
+		return this.consumed;
+	}
+
+	public getAvailable(): number {
+		return Numbers.round(this.getAmount() - this.consumed);
+	}
+
+	public getBuffer(): number {
+		return Numbers.round(this.amount - (this.limit || 0));
+	}
+
+	public getAmount(): number {
+		return this.limit === undefined
+			? this.amount
+			: this.limit;
 	}
 
 }

--- a/src/Tools/Production/Result/Nodes/GraphNode.ts
+++ b/src/Tools/Production/Result/Nodes/GraphNode.ts
@@ -2,10 +2,14 @@ import {ResourceAmount} from '@src/Tools/Production/Result/ResourceAmount';
 import {GraphEdge} from '@src/Tools/Production/Result/Edges/GraphEdge';
 import {IVisNode} from '@src/Tools/Production/Result/IVisNode';
 
+export type HighlightState = 'highlighted'|'dependency'|'dependent'|'product'|'unrelated';
+
 export abstract class GraphNode
 {
 
 	public id: number;
+	public visible: boolean = true;
+	public highlighted?: HighlightState;
 
 	public connectedEdges: GraphEdge[] = [];
 
@@ -17,14 +21,26 @@ export abstract class GraphNode
 
 	public abstract getVisNode(): IVisNode;
 
-	public hasOutputTo(target: GraphNode): boolean
+	public hasOutputTo(target: GraphNode, filter?: string): boolean
 	{
 		for (const edge of this.connectedEdges) {
-			if (edge.from === this && edge.to === target) {
+			if (edge.from === this && edge.to === target && (!filter || edge.itemAmount.item === filter)) {
 				return true;
 			}
 		}
 		return false;
+	}
+
+	public getEdgesOut(filter?: string): GraphEdge[] {
+		return this.connectedEdges.filter((edge) => edge.from === this && (!filter || edge.itemAmount.item === filter));
+	}
+
+	public getEdgesIn(filter?: string): GraphEdge[] {
+		return this.connectedEdges.filter((edge) => edge.to === this && (!filter || edge.itemAmount.item === filter));
+	}
+
+	public isAvailable(): boolean {
+		return this.highlighted !== 'unrelated';
 	}
 
 	protected formatText(text: string, bold: boolean = true)

--- a/src/Tools/Production/Result/Nodes/RecipeNode.ts
+++ b/src/Tools/Production/Result/Nodes/RecipeNode.ts
@@ -10,14 +10,18 @@ import {Numbers} from '@src/Utils/Numbers';
 export class RecipeNode extends GraphNode
 {
 
+	public readonly DELTA = 1e-8;
+
 	public ingredients: ResourceAmount[] = [];
 	public products: ResourceAmount[] = [];
 	public machineData: MachineGroup;
+	public completed: number;
+	public limit?: number;
 
 	public constructor(public readonly recipeData: RecipeData, data: IJsonSchema)
 	{
 		super();
-		const multiplier = this.getMultiplier();
+		const multiplier = this.getMultiplier(this.recipeData.amount);
 		for (const ingredient of recipeData.recipe.ingredients) {
 			this.ingredients.push(new ResourceAmount(data.items[ingredient.item], ingredient.amount * multiplier, 0));
 		}
@@ -25,6 +29,12 @@ export class RecipeNode extends GraphNode
 			this.products.push(new ResourceAmount(data.items[product.item], product.amount * multiplier, product.amount * multiplier));
 		}
 		this.machineData = new MachineGroup(this.recipeData);
+	}
+
+	public getAmount(): number {
+		return this.limit === undefined
+			? this.recipeData.amount
+			: this.limit;
 	}
 
 	public getInputs(): ResourceAmount[]
@@ -39,7 +49,13 @@ export class RecipeNode extends GraphNode
 
 	public getTitle(): string
 	{
-		return this.formatText(this.recipeData.recipe.name) + '\n' + Strings.formatNumber(this.recipeData.amount) + 'x ' + this.recipeData.machine.name;
+		const missing = this.getAmount() - this.completed;
+		const amount = Strings.formatNumber(this.getAmount());
+		const amountText = this.completed
+			? Strings.formatNumber(missing) + ' of ' + amount
+			: amount;
+
+		return this.formatText(this.recipeData.recipe.name) + '\n' + amountText + 'x ' + this.recipeData.machine.name;
 	}
 
 	public getTooltip(): string|null
@@ -65,29 +81,55 @@ export class RecipeNode extends GraphNode
 
 	public getVisNode(): IVisNode
 	{
+		const alpha = Math.abs(this.getAmount() - this.completed) < this.DELTA
+			? '0.25'
+			: '1.0';
+
+		const border = this.highlighted === 'highlighted'
+			? 'rgba(80, 160, 80, 1)'
+			: 'rgba(0, 0, 0, 0)';
+
+		const color =
+			this.highlighted === 'dependent' ? {
+				border: 'rgba(0, 0, 0, 0)',
+				background: `rgba(27, 112, 137, ${alpha})`,
+				highlight: {
+					border: 'rgba(238, 238, 238, 1)',
+					background: 'rgba(38, 159, 194, 1)',
+				},
+			} :
+			this.highlighted === 'product' ? {
+				border: 'rgba(0, 0, 0, 0)',
+				background: `rgba(80, 160, 80, ${alpha})`,
+				highlight: {
+					border: 'rgba(238, 238, 238, 1)',
+					background: 'rgba(111, 182, 111, 1)',
+				},
+			} : {
+				border: border,
+				background: `rgba(223, 105, 26, ${alpha})`,
+				highlight: {
+					border: 'rgba(238, 238, 238, 1)',
+					background: 'rgba(231, 122, 49, 1)',
+				},
+			};
+
 		const el = document.createElement('div');
 		el.innerHTML = this.getTooltip() || '';
 		return {
 			id: this.id,
 			label: this.getTitle(),
 			title: el as unknown as string,
-			color: {
-				border: 'rgba(0, 0, 0, 0)',
-				background: 'rgba(223, 105, 26, 1)',
-				highlight: {
-					border: 'rgba(238, 238, 238, 1)',
-					background: 'rgba(231, 122, 49, 1)',
-				},
-			},
+			color: color,
 			font: {
 				color: 'rgba(238, 238, 238, 1)',
 			},
 		};
 	}
 
-	private getMultiplier(): number
+	public getMultiplier(amount: number): number
 	{
-		return this.recipeData.amount * this.recipeData.machine.metadata.manufacturingSpeed * (this.recipeData.clockSpeed / 100) * (60 / this.recipeData.recipe.time);
+		return amount * this.recipeData.machine.metadata.manufacturingSpeed * (this.recipeData.clockSpeed / 100) * (60 / this.recipeData.recipe.time);
 	}
 
 }

--- a/src/Tools/Production/Result/ProductionResultFactory.ts
+++ b/src/Tools/Production/Result/ProductionResultFactory.ts
@@ -7,21 +7,21 @@ import {MinerNode} from '@src/Tools/Production/Result/Nodes/MinerNode';
 import {ProductNode} from '@src/Tools/Production/Result/Nodes/ProductNode';
 import {ByproductNode} from '@src/Tools/Production/Result/Nodes/ByproductNode';
 import {InputNode} from '@src/Tools/Production/Result/Nodes/InputNode';
-import {Graph} from '@src/Tools/Production/Result/Graph';
+import {Graph, GraphSettings} from '@src/Tools/Production/Result/Graph';
 import {ProductionResult} from '@src/Tools/Production/Result/ProductionResult';
 import {SinkNode} from '@src/Tools/Production/Result/Nodes/SinkNode';
 
 export class ProductionResultFactory
 {
 
-	public create(request: IProductionDataApiRequest, response: IProductionDataApiResponse, data: IJsonSchema): ProductionResult
+	public create(settings: GraphSettings, request: IProductionDataApiRequest, response: IProductionDataApiResponse, data: IJsonSchema): ProductionResult
 	{
-		return new ProductionResult(request, ProductionResultFactory.createGraph(response, data), data);
+		return new ProductionResult(request, ProductionResultFactory.createGraph(settings, request, response, data), data);
 	}
 
-	private static createGraph(response: IProductionDataApiResponse, data: IJsonSchema): Graph
+	private static createGraph(settings: GraphSettings, request: IProductionDataApiRequest, response: IProductionDataApiResponse, data: IJsonSchema): Graph
 	{
-		const graph = new Graph;
+		const graph = new Graph(settings);
 
 		for (const recipeData in response) {
 			if (!response.hasOwnProperty(recipeData)) {
@@ -83,7 +83,7 @@ export class ProductionResultFactory
 			}
 		}
 
-		graph.generateEdges();
+		graph.generateEdges(request.completed || []);
 
 		return graph;
 	}

--- a/src/Tools/Production/Result/ResourceAmount.ts
+++ b/src/Tools/Production/Result/ResourceAmount.ts
@@ -1,10 +1,19 @@
 import {IItemSchema} from '@src/Schema/IItemSchema';
+import { Numbers } from '@src/Utils/Numbers';
 
 export class ResourceAmount
 {
 
 	public constructor(public readonly resource: IItemSchema, public readonly maxAmount: number, public amount: number)
 	{
+	}
+
+	public increase(diff: number) {
+		this.amount = Numbers.round(this.amount + diff);
+	}
+
+	public decrease(diff: number) {
+		this.amount = Numbers.round(this.amount - diff);
 	}
 
 }

--- a/src/Utils/Numbers.ts
+++ b/src/Utils/Numbers.ts
@@ -1,17 +1,17 @@
 export class Numbers
 {
 
-	public static round(num: number, decimals: number = 3): number
+	public static round(num: number, decimals: number = 2): number
 	{
 		return Math.round((num + Number.EPSILON) * Math.pow(10, decimals)) / Math.pow(10, decimals);
 	}
 
-	public static ceil(num: number, decimals: number = 3): number
+	public static ceil(num: number, decimals: number = 2): number
 	{
 		return Math.ceil((num + Number.EPSILON) * Math.pow(10, decimals)) / Math.pow(10, decimals);
 	}
 
-	public static floor(num: number, decimals: number = 3): number
+	public static floor(num: number, decimals: number = 2): number
 	{
 		return Math.floor((num + Number.EPSILON) * Math.pow(10, decimals)) / Math.pow(10, decimals);
 	}

--- a/styles/production.scss
+++ b/styles/production.scss
@@ -84,7 +84,12 @@ $border: 1px solid rgba(0, 0, 0, 0.125);
 		}
 	}
 
-	.input-table {
+	.completed-card {
+		margin-top: 15px;
+	}
+
+	.input-table,
+	.completed-table {
 		width: 100%;
 
 		tr {
@@ -261,6 +266,12 @@ $border: 1px solid rgba(0, 0, 0, 0.125);
 			align-items: center;
 			justify-content: center;
 		}
+	}
+}
+
+.visualization-settings {
+	tr {
+		cursor: pointer;
 	}
 }
 

--- a/templates/Controllers/production.html
+++ b/templates/Controllers/production.html
@@ -366,7 +366,65 @@
 												</td>
 												<td></td>
 												<td>
-													<span class="btn btn-outline-danger" ng-click="ctrl.tab.clearInputs()" tooltip title="Clear inputs">
+													<span class="btn btn-outline-danger" ng-click="ctrl.tab.clearInput()" tooltip title="Clear inputs">
+														<span class="fas fa-fw fa-trash-alt"></span>
+													</span>
+												</td>
+											</tr>
+										</tbody>
+									</table>
+								</div>
+							</div>
+
+							<div class="card completed-card">
+								<h3 class="card-header card-header-with-buttons">
+									<span class="card-header-text">
+										Completed recipes
+									</span>
+								</h3>
+								<div class="card-body">
+									<p>
+										Provide a list of recipes that are already constructed in your factory. The amount of already implemented factories (including their ingredients), will be hidden in the visualization.
+									</p>
+									<table class="completed-table">
+										<tbody ui-sortable="{axis: 'y',  'ui-floating': true, handle: '> .sortable-handler'}" ng-model="ctrl.tab.data.request.completed">
+											<tr ng-repeat="item in ctrl.tab.data.request.completed track by $index">
+												<td class="sortable-handler">
+													<span class="fas fa-arrows-alt-v cursor-drag"></span>
+												</td>
+												<td>
+													<ui-select ng-model="item.recipe" class="production-item-picker">
+														<ui-select-match placeholder="Search or select item">
+															<span>{{$select.selected.name}}</span>
+														</ui-select-match>
+														<ui-select-choices repeat="item.className as item in (ctrl.recipes|filter:{name:$select.search}) track by item.className">
+															<span class="pl-2" ng-bind="item.name"></span>
+														</ui-select-choices>
+													</ui-select>
+												</td>
+												<td>
+													<input class="form-control" ng-show="item.recipe" type="number" ng-model="item.amount" step="any">
+												</td>
+												<td>
+													<span class="btn btn-success" ng-click="ctrl.tab.cloneCompleted(item)" tooltip title="Clone factory">
+														<span class="far fa-fw fa-clone"></span>
+													</span>
+													<span class="btn btn-danger" ng-click="ctrl.tab.removeCompleted(item)" tooltip title="Remove factory">
+														<span class="fas fa-fw fa-times"></span>
+													</span>
+												</td>
+											</tr>
+											<tr>
+												<td></td>
+												<td>
+													<span class="btn btn-outline-success btn-block" ng-click="ctrl.tab.addEmptyCompleted()">
+														<span class="fas fa-plus"></span>
+														Add factory
+													</span>
+												</td>
+												<td></td>
+												<td>
+													<span class="btn btn-outline-danger" ng-click="ctrl.tab.clearCompleted()" tooltip title="Clear factories">
 														<span class="fas fa-fw fa-trash-alt"></span>
 													</span>
 												</td>
@@ -846,9 +904,58 @@
 
 		<div ng-show="ctrl.tab.resultTab === 'visualization'">
 			<div class="border-left border-right border-secondary p-2">
-				You can move the nodes around using drag'n'drop.
+				<p>You can move the nodes around using drag'n'drop.</p>
+				<p>Double click a node to highlight it. In highlight mode only elements and dependencies related to this node is shown.</p>
+
+				<table class="visualization-settings">
+					<tr ng-click="ctrl.tab.toggleApplyCompleted()">
+						<td>
+							<span class="fas fa-check-square" ng-show="ctrl.tab.graphSettings.applyCompleted"></span>
+							<span class="fas fa-square" ng-show="!ctrl.tab.graphSettings.applyCompleted"></span>
+						</td>
+						<td class="d-flex justify-content-between">
+							<span>
+								Apply completed recipes.
+							</span>
+						</td>
+					</tr>
+					<tr ng-click="ctrl.tab.toggleShowCompleted()">
+						<td>
+							<span class="fas fa-check-square" ng-show="ctrl.tab.graphSettings.showCompleted"></span>
+							<span class="fas fa-square" ng-show="!ctrl.tab.graphSettings.showCompleted"></span>
+						</td>
+						<td class="d-flex justify-content-between">
+							<span>
+								Show completed nodes.
+							</span>
+						</td>
+					</tr>
+					<tr ng-click="ctrl.tab.toggleHighlightDependents()">
+						<td>
+							<span class="fas fa-check-square" ng-show="ctrl.tab.graphSettings.showHighlightDependents"></span>
+							<span class="fas fa-square" ng-show="!ctrl.tab.graphSettings.showHighlightDependents"></span>
+						</td>
+						<td class="d-flex justify-content-between">
+							<span>
+								Show the dependents of a recipe in highlight mode.
+							</span>
+						</td>
+					</tr>
+					<tr ng-click="ctrl.tab.toggleHighlightLimits()">
+						<td>
+							<span class="fas fa-check-square" ng-show="ctrl.tab.graphSettings.showHighlightLimits"></span>
+							<span class="fas fa-square" ng-show="!ctrl.tab.graphSettings.showHighlightLimits"></span>
+						</td>
+						<td class="d-flex justify-content-between">
+							<span>
+								Show only resources needed for the current selection in highlight mode.
+							</span>
+						</td>
+					</tr>
+				</table>
 			</div>
-			<visualization result="ctrl.tab.resultNew" ng-class="{visualization: 1, loading: ctrl.tab.state.resultLoading}"></visualization>
+
+			<visualization result="ctrl.tab.resultNew" settings="ctrl.tab.graphSettings" ng-class="{visualization: 1, loading: ctrl.tab.state.resultLoading}"></visualization>
 		</div>
 
 		<div ng-show="ctrl.tab.resultTab === 'items'" class="visualization-result">


### PR DESCRIPTION
Hey guys,

I face the Problem that it is really hard to plan huge factories with the tool. Like having a production graph from raw resources to final tier 9 items is possible, but then I struggled to break it down to smaller graphs to build the actual factory. First I tried to solve it using inputs, but then the overall graph changed because of different inputs and optimizations. So I implemented a couple of features to only change the visual representation of the graph without changing the underlying production graph. I've implemented basically 3 features:

- If two recipes share two (or more) input/output resources, these resources will be consumed first before searching for different alternatives. This is more or less just an optimization for item loops.
![screenshow_loop_optimization](https://github.com/user-attachments/assets/c6487951-4c99-4e97-8dfb-0202d2f8a4fe)
- An additional menu (below the inputs menu) where you can add different recipes. These recipes are used to mark parts of the graph as completed. This can be used to keep the overview while implementing the factory step by step.
![screenshow_completed](https://github.com/user-attachments/assets/faf5752a-a363-4de7-a151-9097417e3c6e)
- It is now possible to select a sub-section of the graph by double clicking on a node. This subsection shows only relevant items for this sub-graph. This makes it easier to keep the overview in really complex scenarios.
![screenshow_sub_graph](https://github.com/user-attachments/assets/40ecb10a-8cd2-4ad7-81da-815de1147b8f)

I've put everything in one commit. Please let me know if you are interested in merging this. If so, I could also cleanup the git history a bit, to give better overview over the changes.
